### PR TITLE
BACKPORT: floss: Disable enhanced sco connection via sysprop

### DIFF
--- a/system/stack/btm/btm_sco.cc
+++ b/system/stack/btm/btm_sco.cc
@@ -33,6 +33,7 @@
 #include "osi/include/allocator.h"
 #include "osi/include/log.h"
 #include "osi/include/osi.h"
+#include "osi/include/properties.h"
 #include "stack/btm/btm_sec.h"
 #include "stack/btm/security_device_record.h"
 #include "stack/include/acl_api.h"
@@ -44,6 +45,13 @@
 #include "types/raw_address.h"
 
 extern tBTM_CB btm_cb;
+
+/* Default to allow enhanced connections where supported. */
+constexpr bool kDefaultDisableEnhancedConnection = false;
+
+/* Sysprops for SCO connection. */
+static const char kPropertyDisableEnhancedConnection[] =
+    "bluetooth.sco.disable_enhanced_connection";
 
 namespace {
 constexpr char kBtmLogTag[] = "SCO";
@@ -140,7 +148,9 @@ static void btm_esco_conn_rsp(uint16_t sco_inx, uint8_t hci_status,
     }
     /* Use Enhanced Synchronous commands if supported */
     if (controller_get_interface()
-            ->supports_enhanced_setup_synchronous_connection()) {
+            ->supports_enhanced_setup_synchronous_connection() &&
+        !osi_property_get_bool(kPropertyDisableEnhancedConnection,
+                               kDefaultDisableEnhancedConnection)) {
       /* Use the saved SCO routing */
       p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH;
 
@@ -341,7 +351,9 @@ static tBTM_STATUS btm_send_connect_request(uint16_t acl_handle,
 
     /* Use Enhanced Synchronous commands if supported */
     if (controller_get_interface()
-            ->supports_enhanced_setup_synchronous_connection()) {
+            ->supports_enhanced_setup_synchronous_connection() &&
+        !osi_property_get_bool(kPropertyDisableEnhancedConnection,
+                               kDefaultDisableEnhancedConnection)) {
       LOG_INFO("Sending enhanced SCO connect request over handle:0x%04x",
                acl_handle);
       /* Use the saved SCO routing */
@@ -1174,7 +1186,9 @@ static tBTM_STATUS BTM_ChangeEScoLinkParms(uint16_t sco_inx,
 
     /* Use Enhanced Synchronous commands if supported */
     if (controller_get_interface()
-            ->supports_enhanced_setup_synchronous_connection()) {
+            ->supports_enhanced_setup_synchronous_connection() &&
+        !osi_property_get_bool(kPropertyDisableEnhancedConnection,
+                               kDefaultDisableEnhancedConnection)) {
       /* Use the saved SCO routing */
       p_setup->input_data_path = p_setup->output_data_path = ESCO_DATA_PATH;
 


### PR DESCRIPTION
Commit 7279b5633c63acf2a30b10b9743ff90df88a4d61 upstream.

Add a new sysprop, "bluetooth.sco.disable_enhanced_connection", so that we can disable it on controllers where we know this is broken but can't fix the firmware.

Bug: 255202220
Tag: #floss
Test: Ran HFP tests with value set to true and false.
Change-Id: Ib12f09d80c26b65e66fe14de9181230520a90ffc